### PR TITLE
Parse command line and add helper methods for libclang interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/docs/
+/lib/
+/bin/
+/.shards/
+shard.lock
+*.dwarf
+isekai

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+isekai: src/isekai.cr $(wildcard src/**/*.cr)
+	crystal build src/isekai.cr
+
+.PHONY: test
+test: $(wildcard src/**/*.cr) $(wildcard spec/*.cr)
+	crystal spec
+
+.PHONY: clean
+clean:
+	rm isekai

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # isekai
 Isekai verifiable computation project
+
+# Building the project
+
+## Compiling
+
+The project comes with the Makefile and in order to compile the
+project, running `make` will be enough. That will create `isekai`
+binary file in the current directory. To run tests `make test`
+should be used.
+
+Alternatively, `crystal build src/isekai.cr` or `crystal test`
+can be used.
+
+## Dependencies
+
+The project is written in Crystal language. Follow the [Official
+instructions](https://crystal-lang.org/docs/installation/) for instructions how
+to install Crystal lang. The only library dependency is `libclang` library. On
+Ubuntu it can be installed via `sudo apt install libclang1-6.0`. 

--- a/shard.yml
+++ b/shard.yml
@@ -1,0 +1,21 @@
+name: isekai
+version: 0.1.0
+
+authors:
+  - Nemanja Boric <nemanja@nemanjaboric.com>
+
+targets:
+  isekai:
+    main: src/isekai.cr
+
+crystal: 0.26.1
+
+license: GPL
+
+dependencies:
+  clang:
+    github: Burgos/clang.cr
+    branch: master
+  linked_list:
+    github: abvdasker/crystal-linked-list
+    branch: master

--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -1,0 +1,32 @@
+require "./spec_helper"
+require "../src/parser.cr"
+
+describe Isekai do
+    cursor = parse_c_code("void foo(int x, int y)
+                                   { 
+                                      int z = x + 1; 
+                                      if (z == 1) { int w = 0; }
+                                      else { int w = 1; }
+                                   }")
+
+    func_body = Isekai::ClangUtils.findFunctionBody(cursor)
+    raise "findFunctionBody failed" if func_body.is_a? Nil
+    func_body.kind.should eq Clang::CursorKind::CompoundStmt
+
+    fun_params = Isekai::ClangUtils.findFunctionParams(cursor)
+    fun_params.size.should eq 2
+
+    decl_statement = Isekai::ClangUtils.getFirstChild(func_body)
+    raise "Can't find decl statement declaration" if decl_statement.is_a? Nil
+    decl_statement.kind.should eq Clang::CursorKind::DeclStmt
+
+    var_decl = Isekai::ClangUtils.getFirstChild(decl_statement)
+    raise "Can't find variable declaration declaration" if var_decl.is_a? Nil
+    var_decl.kind.should eq Clang::CursorKind::VarDecl
+
+    binary_expr = get_first_child_of_kind(var_decl, Clang::CursorKind::BinaryOperator)
+    raise "Can't find binary expression" if binary_expr.is_a? Nil
+
+    binary_elements = Isekai::ClangUtils.getBinaryOperatorExprs(binary_expr)
+    binary_elements.size.should eq 2
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,0 +1,52 @@
+require "spec"
+require "../src/parser.cr"
+require "clang"
+
+# Parses the C code and returns libclang cursor
+#
+# Params:
+#     code = C code represented as string
+#
+# Returns:
+#     libclang's cursor representing the input code
+def parse_c_code (code : String)
+    unsaved_file = Clang::UnsavedFile.new("file.c", code)
+    options = Clang::TranslationUnit.default_options
+    index = Clang::Index.new
+
+    # 2. Load the file and get the translation unit
+    tu = Clang::TranslationUnit.from_source(index, [unsaved_file], [""], options)
+
+    # 3. skip all macro cursors
+    real_cursor = tu.cursor
+    tu.cursor.visit_children do |child|
+        case child.kind
+        when .macro_definition?
+            next Clang::ChildVisitResult::Continue
+        else
+            real_cursor = child
+            next Clang::ChildVisitResult::Break
+        end
+    end
+    return real_cursor
+end
+
+# Gets the first child in the tree of a given kind
+#
+# Params:
+#     cursor = libclang cursor to query the children nodes
+#     child_kind = the kind of the child to return
+def get_first_child_of_kind (cursor, child_kind)
+    real_cursor = nil
+    cursor.visit_children do |child|
+        case child.kind
+        when child_kind
+            real_cursor = child
+            next Clang::ChildVisitResult::Break
+        else
+            next Clang::ChildVisitResult::Continue
+        end
+    end
+
+    return real_cursor
+end

--- a/src/isekai.cr
+++ b/src/isekai.cr
@@ -65,6 +65,7 @@ module Isekai
 
             filename = ARGV[-1]
 
+            Log.setup(opts.progress)
             parser = CParser.new(filename,
                                  opts.clang_args,
                                  opts.loop_sanity_limit,

--- a/src/isekai.cr
+++ b/src/isekai.cr
@@ -1,0 +1,75 @@
+require "option_parser"
+require "./parser.cr"
+
+module Isekai
+    # Structure holding the options passed by the user
+    # on the command line
+    struct ProgramOptions
+        # Additional arguments to pass to libclang (e.g. -I)
+        property clang_args = ""
+        # Dynamic loop unrolling limit
+        property loop_sanity_limit = 0
+        # Print progress during the execution
+        property progress = false
+        # Arithmetic circuit output file - the program will output
+        # an arithmetic circuit if set
+        property arith_file = ""
+        # Boolean circuit output file - the program will output
+        # an boolean circuit if set
+        # an arithmetic circuit if set
+        property bool_file = ""
+        # Number of bits in the word - used in the bitwise operations
+        # (left shift/right shift/etc) and in calculations/side-effects that
+        # are bitwidth-aware - 2nd complement's arithmetic/overflow detection
+        # truncation
+        property bit_width = 32
+        # Print the resulting expressions
+        property print_exprs = false
+        # Ignore overflow
+        property ignore_overflow = false
+    end
+
+    class ParserProgram
+        # Main 
+        def main
+            opts = ProgramOptions.new
+
+            # Parse the program options. For the detailed
+            # explanations refer to struct ProgramOptions
+            OptionParser.parse! do |parser|
+                parser.banner = "Usage: isekai [arguments] file"
+                parser.on("-c", "--cpparg=ARGS", "Extra arguments to clang")\
+                    { |args| opts.clang_args = args }
+                parser.on("-a", "--arith=FILE", "Arithmetic circuit output file")\
+                    { |file| opts.arith_file = file }
+                parser.on("-b", "--bool=FILE", "Boolean circuit output file")\
+                    { |file| opts.bool_file = file }
+                parser.on("-w", "--bit-width", "Width of the word in bits (used for overflow/bitwise operations)")\
+                    { |width| opts.bit_width = width.to_i() }
+                parser.on("-l", "--loop-sanity-limit=LIMIT", "Limit on statically-measured loop unrolling")\
+                    { |limit| opts.loop_sanity_limit = limit.to_i }
+                parser.on("-p", "--progress", "Print progress messages during compilation")\
+                    { opts.progress = true }
+                parser.on("-i", "--ignore-overflow", "Ignore field-P overflows; never truncate")\
+                    { opts.ignore_overflow = true }
+                parser.on("-x", "--print-exprs", "Print output expressions to stdout")\
+                    { opts.print_exprs = true }
+                parser.on("-h", "--help", "Show this help") { puts parser; exit 0 }
+            end
+
+            # Filename is passed as the last argument.
+            if ARGV.size() != 1
+                puts "There should be exactly one file argument"
+                exit 1
+            end
+
+            filename = ARGV[-1]
+
+            parser = CParser.new(filename,
+                                 opts.clang_args,
+                                 opts.loop_sanity_limit,
+                                 opts.bit_width, opts.progress)
+        end
+    end
+end
+(Isekai::ParserProgram.new).main()

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -27,6 +27,294 @@ module Isekai
       end
     end
 
+    # Auxilary wrappers for the libclang cursors
+    # Provides helpers around the common methods
+    # on the libclang interface
+    class ClangUtils
+      # Extracts the function's body (a cursor to CompoundStmt)
+      # from the function definition cursor
+      #
+      # Parameters:
+      #    function_cursor = Clang::Cursor representing the function
+      #
+      # Returns:
+      #    compound statement representing the function's body
+      def self.findFunctionBody (function_cursor)
+          function_body_cursor = nil
+          function_cursor.visit_children do |cursor|
+              case cursor.kind
+              when .compound_stmt?
+                  function_body_cursor = cursor
+                  next Clang::ChildVisitResult::Break
+              else
+                  next Clang::ChildVisitResult::Continue
+              end
+          end
+          function_body_cursor
+      end
+
+      # For the given cursor to an expression, return
+      # the cursor to the concrete expression, skipping
+      # potential FirstExpr (which is a marker AST node)
+      #
+      # Params:
+      #     cursor = cursor to the expression
+      # Returns:
+      #     the concrete expression, unwrapping the FirstExpr
+      #     marker layer
+      def self.getConcreteExpression (cursor)
+          if !cursor.kind.first_expr?
+              return cursor
+          end
+
+          result = nil
+          cursor.visit_children do |child|
+              case child.kind
+              when .first_expr?
+                  next Clang::ChildVisitResult::Continue
+              else
+                  result = child
+                  next Clang::ChildVisitResult::Break
+              end
+          end
+
+          # Never return Nil, raise if not found
+          if cur_res = result
+              return cur_res
+          else
+              raise "Can't resolve FirstExpr"
+          end
+      end
+
+      # Dumps the AST from the cursor to stdout.
+      def self.dumpCursorAst (cursor)
+          puts "* #{cursor}"
+          cursor.visit_children do |child|
+              puts "- Child #{child}"
+              next Clang::ChildVisitResult::Recurse
+          end
+      end
+
+      # Returns the operands used in the binary operation
+      #
+      # Params:
+      #     cursor = binary operator expression
+      #
+      # Returns:
+      #     an array with two members representing two
+      #     operands in the binary operation
+      #
+      def self.getBinaryOperatorExprs (cursor)
+          result = Array(Clang::Cursor).new
+          cursor.visit_children do |child|
+              result << child
+              next Clang::ChildVisitResult::Continue
+          end
+
+          raise "Error parsing binary operator #{cursor}" unless result.size == 2
+
+          return result
+      end
+
+      # Returns the condition, then branch and else branch for the
+      # if-statement
+      #
+      # Params:
+      #     cursor = cursor pointing to the if statement
+      #
+      # Returns:
+      #     an array containing the following elements of the if statement:
+      #         1. condition
+      #         2. then body
+      #         3. (optional) else body
+      #
+      def self.getIfStatementExprs (cursor)
+          result = Array(Clang::Cursor).new
+          cursor.visit_children do |child|
+              result << child
+              next Clang::ChildVisitResult::Continue
+          end
+
+          if (result.size < 2 || result.size > 3)
+              raise "Unexpected number of children for if statement op. #{cursor}"
+          end
+
+          return result
+      end
+
+      # Extracts the function parameters from the function declaration
+      #
+      # Params:
+      #     func_decl_cursor = cursor pointing to the functiond declaration
+      #
+      # Returns:
+      #     an array with cursors representing the function parameters
+      #
+      def self.findFunctionParams (func_decl_cursor)
+          result = Array(Clang::Cursor).new
+          func_decl_cursor.visit_children do |child|
+              if child.kind.parm_decl?
+                  result << child
+              end
+              next Clang::ChildVisitResult::Continue
+          end
+
+          return result
+      end
+
+      # Gets the first child for the given cursor - an utility
+      # to wrap very common operating during the code transformation
+      #
+      # Params:
+      #    cursor = cursor to extract the child cursor from
+      #
+      # Returns:
+      #    the cursor to the first child node of the input cursor
+      #
+      def self.getFirstChild (cursor)
+          result = nil
+
+          cursor.visit_children do |child|
+              result = child
+              next Clang::ChildVisitResult::Break
+          end
+
+          return result
+      end
+
+      # Gets the cursor to the type reference for the given
+      # variable declaration.
+      #
+      # Params:
+      #    cursor = cursor to the variable declaration
+      #
+      # Returns:
+      #    a cursor to TypeRef node referring to the type
+      #    of the variable that's being declared
+      #
+      def self.getTypeRefChild (cursor)
+          typeref_cursor = nil
+          cursor.visit_children do |child|
+              case child.kind
+              when .type_ref?
+                  typeref_cursor = child
+                  Log.log.warn "Found type_ref child: #{typeref_cursor}"
+                  next Clang::ChildVisitResult::Break
+              else
+                  next Clang::ChildVisitResult::Continue
+              end
+          end
+
+          return typeref_cursor
+      end
+
+      # Returns the dimension of the array
+      #
+      # Params:
+      #     cursor = array cursor
+      #
+      # Returns:
+      #     declared number of the elements in the array
+      #
+      def self.getArrayDimension (cursor)
+          if cursor.is_a? Clang::Type
+              return cursor.num_elements.to_i32
+          else
+              return cursor.type.num_elements.to_i32
+          end
+          return -1
+      end
+
+      # Extracts the struct fields from the struct.
+      #
+      # Params:
+      #    struct_cursor = cursor pointing to the struct definition
+      #
+      # Returns:
+      #    an array of the struct fields
+      #
+      def self.getStructFields (struct_cursor)
+          struct_fields = Array(Clang::Cursor).new
+          struct_cursor.visit_children do |child|
+              case child.kind
+              when .field_decl?
+                  struct_fields << child
+                  Log.log.warn "Found struct field child: #{child}"
+              end
+              next Clang::ChildVisitResult::Continue
+          end
+          return struct_fields
+      end
+
+      # Gets the value for the literal
+      #
+      # Params:
+      #     cursor = literal cursor
+      #
+      # Returns:
+      #     value of the literal behind the cursor
+      #
+      def self.getValue (cursor)
+          result = nil
+          case cursor.kind
+          when .integer_literal?
+              result = cursor.literal.to_i
+          else
+              raise "Getting value of the non-literal"
+          end
+          return result
+      end
+
+
+      # Gets the initializer for the variable.
+      #
+      # Params:
+      #    cursor = variable declaration cursor
+      #
+      # Returns:
+      #    the literal value for the initializer
+      #
+      # Raises an error if the variable doesn't have constant
+      # initializer
+      def self.getVariableInitializer (cursor : Clang::Cursor)
+          result = nil
+          if result = getValue(cursor)
+              return result
+          end
+
+          if child = getFirstChild(cursor)
+              if result = getValue(child)
+                  return result
+              end
+          end
+
+          if result.is_a? Nil
+              dumpCursorAst(cursor)
+              raise "Can't get the initializer: #{cursor}"
+          else
+              return result
+          end
+      end
+
+
+      # Checks if the variable declaration has an initializer
+      #
+      # Params:
+      #    cursor = variable declaration cursor
+      #
+      # Returns:
+      #    true if the variable declaration has an initializer
+      #
+      def self.hasInitilizer (var_decl_cursor : Clang::Cursor)
+          result = false
+          var_decl_cursor.visit_children do |child|
+              result = true
+              Clang::ChildVisitResult::Break
+          end
+          return result
+      end
+    end
+
     # Class that parses and transforms C code into internal state
     class CParser
         # Initialization method.

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -4,6 +4,29 @@ require "logger"
 module Isekai
     VERSION = "0.1.0"
 
+    # Simple wrapper around the logger's instance.
+    # Takes care of the Logger's setup and holds Logger instance
+    class Log
+      @@log = Logger.new(STDOUT)
+
+      # Setup the logger
+      # Parameters:
+      #     verbose = be verbose at the output
+      def self.setup (verbose = false)
+          if verbose
+              @@log.level = Logger::DEBUG
+          else
+              @@log.level = Logger::WARN
+          end
+      end
+
+      # Returns:
+      #     the logger instance
+      def self.log
+          @@log
+      end
+    end
+
     # Class that parses and transforms C code into internal state
     class CParser
         # Initialization method.

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -1,0 +1,20 @@
+require "clang"
+require "logger"
+
+module Isekai
+    VERSION = "0.1.0"
+
+    # Class that parses and transforms C code into internal state
+    class CParser
+        # Initialization method.
+        # Parameters:
+        #   input_file = C file to read
+        #   clang_args = arguments to pass to clang (e.g. include directories)
+        #   loop_sanity_limit = sanity limit to stop unrolling loops
+        #   bit_width = bit width
+        #   progress = print progress during processing
+        def initialize (@input_file : String, @clang_args : String, @loop_sanity_limit : Int32,
+                        @bit_width : Int32, @progress = false)
+        end
+    end
+end


### PR DESCRIPTION
This adds the Isekai main program class which reads the command
line arguments and creates the CParser instance which will parse the
input C file and output the arithmetic circuits. Additionally, this PR introduces
helpers for abstracting some of the operations with libclang.