### PR TITLE
Add intermediate graph representation support. 

### DIFF
--- a/spec/dfg_spec.cr
+++ b/spec/dfg_spec.cr
@@ -1,0 +1,15 @@
+require "spec"
+require "../src/dfg.cr"
+require "../src/frontend/storage.cr"
+require "../src/frontend/types.cr"
+require "../src/frontend/symbol_table_key.cr"
+
+describe Isekai do
+    storage1 = Isekai::Storage.new("x", 1)
+
+    storage_ref = Isekai::StorageRef.new(Isekai::IntType.new, storage1, 1)
+    storage_ref.key.should eq Isekai::StorageKey.new(storage1, 1)
+
+    ref = storage_ref.ref
+    ref.deref.key.should eq Isekai::StorageKey.new(storage1, 1)
+end

--- a/spec/frontend_storage_spec.cr
+++ b/spec/frontend_storage_spec.cr
@@ -1,0 +1,23 @@
+require "spec"
+require "../src/frontend/storage.cr"
+
+describe Isekai do
+    nul1 = Isekai::Storage.null()
+    nul2 = Isekai::Storage.null()
+
+    if !(nul1.is_a? Isekai::Null)
+        raise "Null is not an instance of Null storage"
+    end
+
+    # make sure we have a single null storage
+    nul1.should eq nul2
+
+    storage1 = Isekai::Storage.new("x", 1)
+    storage2 = Isekai::Storage.new("x", 1)
+     
+    # make sure the storage identity doesn't depend
+    # on the label/size
+    storage1.should_not eq storage2
+    storage1.hash.should_not eq storage2.hash
+end
+

--- a/spec/frontend_symbol_table_key_spec.cr
+++ b/spec/frontend_symbol_table_key_spec.cr
@@ -1,0 +1,17 @@
+require "spec"
+require "../src/frontend/storage.cr"
+require "../src/frontend/symbol_table_key.cr"
+
+describe Isekai do
+    storage = Isekai::Storage.new("instance", 10)
+
+    key1 = Isekai::StorageKey.new(storage, 1)
+    key11 = Isekai::StorageKey.new(storage, 1)
+    key2 = Isekai::StorageKey.new(storage, 2)
+
+    key1.should eq key11
+    key1.should_not eq key2
+    key1.hash.should eq key11.hash
+    key1.hash.should_not eq key2.hash
+end
+

--- a/spec/frontend_symbol_table_spec.cr
+++ b/spec/frontend_symbol_table_spec.cr
@@ -1,0 +1,39 @@
+require "spec"
+require "../src/frontend/storage.cr"
+require "../src/frontend/symbol_table_key.cr"
+require "../src/frontend/symbol_table_value.cr"
+require "../src/frontend/types.cr"
+require "../src/frontend/symbol_table.cr"
+
+describe Isekai do
+    storage1 = Isekai::Storage.new("x", 1)
+    storage2 = Isekai::Storage.new("x", 1)
+    storage3 = Isekai::Storage.new("x", 1)
+
+    storage = Isekai::Storage.new("instance", 10)
+
+    key1 = Isekai::StorageKey.new(storage, 1)
+    key11 = Isekai::StorageKey.new(storage, 1)
+    key2 = Isekai::StorageKey.new(storage, 2)
+    key3 = Isekai::StorageKey.new(storage, 3)
+
+    parent_symtable = Isekai::SymbolTable.new(nil, Set(Isekai::Key).new)
+    symtable = Isekai::SymbolTable.new(parent_symtable, Set(Isekai::Key).new)
+
+    symtable.is_declared?(key1).should eq false
+    symtable.declare(key1, storage1)
+    symtable.is_declared?(key1).should eq true
+
+    symtable.lookup(key1).should eq storage1
+
+    # Access the symbol from the parent scope
+    parent_symtable.declare(key2, storage2)
+    symtable.lookup(key2).should eq storage2
+
+    # assign the key through the assign method, without declaring it
+    symtable.assign(key2, storage3)
+    scope = symtable.getScope()
+    scope.includes?(key1).should eq false
+    scope.includes?(key2).should eq true
+end
+

--- a/spec/frontend_types_spec.cr
+++ b/spec/frontend_types_spec.cr
@@ -1,0 +1,15 @@
+require "spec"
+require "../src/frontend/types.cr"
+
+describe Isekai do
+    fields = [Isekai::StructField.new(Isekai::IntType.new(), "a"),
+              Isekai::StructField.new(Isekai::UnsignedType.new(), "b")]
+    my_struct = Isekai::StructType.new("my_struct", fields)
+
+    exp_size = (Isekai::IntType.new().sizeof + Isekai::UnsignedType.new().sizeof)
+    my_struct.sizeof.should eq exp_size
+
+    my_struct.offsetof("a").should eq 0
+    my_struct.offsetof("b").should eq my_struct.get_field("a").@type.sizeof
+end
+

--- a/src/dfg.cr
+++ b/src/dfg.cr
@@ -1,0 +1,261 @@
+require "./frontend/types.cr"
+require "./frontend/storage.cr"
+require "./dfgoperator"
+
+module Isekai
+
+# Internal expression node. All internal state expressions
+# are instances of this class
+class DFGExpr < SymbolTableValue
+end
+
+# Undefined operation. Raised if the operation is not supported.
+class Undefined < DFGExpr
+end
+
+# Abstract operation
+class Op < DFGExpr
+end
+
+# Operation on the array.
+class ArrayOp < Op
+end
+
+# Reference to the part of an existing node
+class StorageRef < ArrayOp
+    # Constructs a reference to a storage.
+    #
+    # Params:
+    #     type = type of the storage
+    #     storage = storage instance
+    #     idx = index in the storage
+    def initialize (@type : Type, @storage : Storage, @idx : Int32)
+    end
+
+    # Returns:
+    #     true if the StorageRef instance refers to a pointer
+    def is_ptr?
+        @type.is_a? PtrType 
+    end
+
+    # Returns:
+    #    StorageKey instance pointing to the offset in th estorage
+    def offset_key (offset)
+        raise "Getting the offset out of the non-pointer" unless !is_ptr?
+        return StorageKey.new(@storage, @idx + offset)
+    end
+
+    # Returns:
+    #     symbol-table key analog to this storage ref
+    def key
+        if is_ptr?
+            raise "Trying to eagerly lookup ptr"
+        end
+
+        return StorageKey.new(@storage, @idx)
+    end
+
+    # Creates reference to this storage
+    # Returns:
+    #     a StorageRef instance referring to this storage reference
+    def ref
+        raise "Can't get reference to a pointer" unless !is_ptr?
+        return StorageRef.new(PtrType.new(@type), @storage, @idx)
+    end
+
+    # Resolves a reference to the storage
+    # Returns:
+    #     a StorageRef instance which is a result of dereferencing
+    #     this StorageRef (inverse of ref operation)
+    def deref
+        ptr_type = @type.as PtrType
+        return StorageRef.new(ptr_type.@base_type, @storage, @idx)
+    end
+end
+
+# Integer constant node
+class Constant < DFGExpr
+    def initialize (@value : Int32)
+    end
+end
+
+# Conditional node. Consists itself of the condition, then and else branches.
+class Conditional < Op
+    def initialize (@cond : DFGExpr, @valtrue : DFGExpr, @valfalse : DFGExpr)
+    end
+
+    def_equals @cond, @valtrue, @valfalse 
+end
+
+# Binary operation. Perform `@op` on two operands `@left` and `@right`
+class BinaryOp < Op
+    def initialize (@op : String, @left : DFGExpr, @right : DFGExpr)
+    end
+end
+
+# Binary mathematial operation. Performs `@op` (also represented by `DFGOperator`)
+# on `@left` and `@right`, with the optional identity element (e.g. 0 for addition, 1 for multiplication).
+class BinaryMath < BinaryOp
+    def initialize (@op, @crystalop : DFGOperator, @identity : (Int32|Nil), @left, @right)
+        super(@op, @left, @right)
+    end
+end
+
+# Add operation
+class Add < BinaryMath
+    def initialize (@left, @right)
+        super("+", OperatorAdd.new, 0, @left, @right)
+    end
+end
+
+# Multiply operation
+class Multiply < BinaryMath
+    def initialize (@left, @right)
+        super("*", OperatorMul.new, 1, @left, @right)
+    end
+end
+
+
+# Subtract operation
+class Subtract < BinaryMath
+    def initialize (@left, @right)
+        super("+", OperatorSub.new, 0, @left, @right)
+    end
+end
+
+
+# Divide operation
+class Divide < BinaryMath
+    def initialize (@left, @right)
+        super("/", OperatorDiv.new, 1, @left, @right)
+    end
+end
+
+# Modulo operation
+class Modulo < BinaryMath
+    def initialize (@left, @right)
+        super("%", OperatorMod.new, 1, @left, @right)
+    end
+end
+
+# Exclusive OR operation
+class Xor < BinaryMath
+    def initialize (@left, @right)
+        super("^", OperatorXor.new, 1, @left, @right)
+    end
+end
+
+# Left shift operation
+class LeftShift < BinaryMath
+    def initialize (@left, @right, @bit_width : Int32)
+        super("<<", LeftShiftOp.new(@bit_width), 0, @left, @right)
+    end
+end
+
+# Right shift operation
+class RightShift < BinaryMath
+    def initialize (@left, @right, @bit_width : Int32)
+        super(">>", RightShiftOp.new(@bit_width), 0, @left, @right)
+    end
+end
+
+# bitwise-or operation
+class BitOr < BinaryMath
+    def initialize (@left, @right)
+        super("|", OperatorBor.new, 0, @left, @right)
+    end
+end
+
+# bitwise-and operation
+class BitAnd < BinaryMath
+    def initialize (@left, @right)
+        super("&", OperatorBAnd.new, nil, @left, @right)
+    end
+end
+
+# Logical And operation
+class LogicalAnd < BinaryMath
+    def initialize (@left, @right)
+        super("^", LogicalAndOp.new, nil, @left, @right)
+    end
+end
+
+# Less-than compare operation
+class CmpLT < BinaryOp
+    def initialize (@left, @right)
+        super("<", @left, @right)
+    end
+end
+
+# Less-than-or-equal compare operation
+class CmpLEQ < BinaryOp
+    def initialize (@left, @right)
+        super("<=", @left, @right)
+    end
+end
+
+# Equal compare operation
+class CmpEQ < BinaryOp
+    def initialize (@left, @right)
+        super("==", @left, @right)
+    end
+end
+
+# Greater-than compare operation
+class CmpGT < BinaryOp
+    def initialize (@left, @right)
+        super(">", @left, @right)
+    end
+end
+
+# Greater-than compare operation
+class CmpGEQ < BinaryOp
+    def initialize (@left, @right)
+        super(">=", @left, @right)
+    end
+end
+
+# Unary operation. Perform `@op` on `@expr`
+class UnaryOp < Op
+    def initialize (@op : String, @expr : DFGExpr)
+    end
+
+end
+
+# Logical-Not unary operation
+class LogicalNot < UnaryOp
+	def initialize (@expr)
+		super("Not", @expr)
+    end
+end
+
+# Bitwise-Not unary operation
+class BitNot < UnaryOp
+	def initialize(@expr, @bit_width)
+		super("BitNot", @expr)
+    end
+end
+
+# Negate unary operation
+class Negate < UnaryOp
+	def initialize(@expr)
+		super("Negate", @expr)
+    end
+end
+
+# Program input expression. The subclass for both NIZK and regular
+# input classes
+class InputBase < DFGExpr
+    def initialize(@storage_key : StorageKey)
+    end
+end
+
+# Regular program input expression. Passed as an argument to outsource method
+class Input < InputBase
+end
+
+# NIZK program input expression. Passed as an optional argument to outsource method
+class NIZKInput < InputBase
+end
+
+end

--- a/src/dfgoperator.cr
+++ b/src/dfgoperator.cr
@@ -1,0 +1,40 @@
+# Operators on DFGExpressions. Wraps the operation in a type-safe manner.
+class DFGOperator
+end
+
+class LeftShiftOp < DFGOperator
+    def initialize (@bitwidth : Int32)
+    end
+end
+
+class RightShiftOp < DFGOperator
+    def initialize (@bitwidth : Int32)
+    end
+end
+
+class LogicalAndOp < DFGOperator
+end
+
+class OperatorAdd < DFGOperator
+end
+
+class OperatorSub < DFGOperator
+end
+
+class OperatorMul < DFGOperator
+end
+
+class OperatorDiv < DFGOperator
+end
+
+class OperatorMod < DFGOperator
+end
+
+class OperatorXor < DFGOperator
+end
+
+class OperatorBor < DFGOperator
+end
+
+class OperatorBAnd < DFGOperator
+end

--- a/src/frontend/storage.cr
+++ b/src/frontend/storage.cr
@@ -1,0 +1,28 @@
+require "./symbol_table_value"
+
+module Isekai
+
+# Storage instance. Storage is analog to the memory
+# location where the state of the given type is stored.
+# Object of this class is unique and distinctive - the label
+# is just a label and it doesn't makes the objects identity
+class Storage < SymbolTableValue
+    def initialize(@label : String, @size : Int32)
+    end
+
+    # Returns a null storage instance.
+    def self.null
+        if @@null == nil
+            @@null = Null.new()
+        end
+        return @@null
+    end
+end
+
+# Null storage
+class Null < Storage
+    def initialize()
+        super("null", 0)
+    end
+end
+end

--- a/src/frontend/symbol_table.cr
+++ b/src/frontend/symbol_table.cr
@@ -1,0 +1,187 @@
+require "./symbol_table_key.cr"
+require "./symbol_table_value.cr"
+require "./storage.cr"
+require "./types.cr"
+
+module Isekai
+
+# Exception raised when trying to lookup
+# not existing symbol
+class UndefinedSymbolException < Exception
+end
+
+# Exception raised when trying to declare
+# an already declared symbol
+class DuplicateDeclarationException < Exception
+end
+
+# Symbol table.
+# instance variables:
+#   @ depth = depth of the current scope
+#   @ decl_table = set of declared variable names
+#   @ assign_table = maps string identifiers to List(DFGExpr)
+#   @ scope = if present, collects assigned keys
+#             that are declared/modified in this scope
+#             (to track side-effects)
+#
+# class variables:
+#   @@ max_depth = maximum encountered scope level
+class SymbolTable
+    @@max_depth = 0
+
+    def initialize ()
+        initialize(nil, nil)
+    end
+
+    # Constructs a symbol table.
+    #
+    #
+    # Params:
+    #     parent = parent symbol table (the enclosing scope)
+    #     scope = set of the affected variables when applying expressions
+    #             in this scope
+    def initialize (@parent : (SymbolTable|Nil), @scope : (Set(Key)|Nil))
+        @decl_table = Set(Key).new
+        @assign_type_table = Hash(Key, SymbolTableValue).new
+
+        if (@parent != nil)
+            @depth = @parent.not_nil!.@depth + 1
+            if (@depth > @@max_depth)
+                @@max_depth += 1
+                if @@max_depth > 100
+                    raise "Too deep AST - symbol table is over 100 levels deep"
+                end
+            end
+        else
+            @depth = 0
+        end
+    end
+
+    # Returns: 
+    #     indicator if the symbol was already declared
+    def is_declared? (key)
+        @decl_table.includes? key
+    end
+
+    # Returns:
+    #     list of the modified symbols
+    def getScope : Set(Key)
+        if scope = @scope
+            return scope
+        else
+            raise "No scope was set"
+        end
+    end
+
+    # declares a new symbol
+    def declare (key, value)
+        if is_declared? key
+            raise DuplicateDeclarationException.new
+        end
+
+        # Declare symbol and add its value
+        @decl_table.add(key.as(Key))
+        @assign_type_table[key.as(Key)] = value.as(SymbolTableValue)
+    end
+
+    # Assigns the value with the key
+    def assign (key, value)
+        # This symbol's value is valid in this and all enclosing
+        # scopes. Propagate this assignemnt.
+        propagate(key)
+        @assign_type_table[key.as(Key)] = value.as(SymbolTableValue)
+
+        # Note the side-effect to @scope
+        note_assignment(key)
+    end
+
+    # Look up the value for the key in this and
+    # all parent scopes
+    #
+    # Params:
+    #     key = key to lookup
+    #
+    # Returns:
+    #     value of the symbol behind the key.
+    def lookup (key) : SymbolTableValue
+        raise "Passed not Key #{key.inspect}" unless key.is_a? Key
+        return propagate(key)
+    end
+
+    # Finds the key in this or in parent's scope
+    # and brings it to the current scope.
+    #
+    # Params:
+    #     key = entry to look for
+    #
+    # Returns:
+    #     value associated with key
+    protected def propagate (key)
+        if value = fetch(key)
+            @assign_type_table[key.as(Key)] = value
+            return value
+        end
+        raise "Unknown type"
+    end
+
+    # Fetches the key from this or any parent scopes.
+    # Raises UndefinedSymbol exception if not found
+    protected def fetch (key)
+        val = @assign_type_table[key]?
+        if val != nil
+            return val
+        end
+
+        if parent = @parent
+            return parent.fetch(key)
+        else
+            raise UndefinedSymbolException.new
+        end
+    end
+
+    # Notes the side effect in the current scope.
+    protected def note_assignment(key)
+        if @decl_table.includes? key
+            # It's already modified in this scope
+            return
+        else
+            if scope = @scope
+                scope.add(key)
+            end
+            if parent = @parent
+                parent.note_assignment(key)
+            end
+        end
+    end
+
+    # builds string representation
+    def to_s
+        ding = "SCOPE" unless @scope == nil
+        if @scope == nil
+            ding = ""
+        else
+            ding = "(SCOPE)"
+        end
+
+        return @assign_table.to_s + ding
+    end
+
+    # Goes over the current scope, and for every
+    # symbol in the current scope it copies the value
+    # from the extract_symbtab and assigns it to the
+    # apply_symtab - applying the changes done in the
+    # side effects symbol table.
+    def apply_changes (extract_symtab, apply_symtab)
+        result_symtab = apply_symtab
+        if scope = @scope
+            scope.each do |key|
+                value = extract_symtab.lookup(key)
+                result_symtab.assign(key, value)
+            end
+        else
+            raise "Symbol table is invalid - missing scope"
+        end
+        return result_symtab
+    end
+end
+end

--- a/src/frontend/symbol_table_key.cr
+++ b/src/frontend/symbol_table_key.cr
@@ -1,0 +1,60 @@
+require "./storage.cr"
+
+module Isekai
+    # Base class for keys for Symbol table entries.
+    # Symbol table holds two classes of keys - symbols,
+    # which refer to declaration of variables and StorageKeys - which
+    # refer to the storage instances (for example, struct fields or
+    # variable instances)
+    class Key
+    end
+
+    # Entry in the symbol table for the symbols.
+    class Symbol < Key
+
+        # Constructs the symbol
+        # Params:
+        #     name = name of the symbol
+        def initialize (@name : String)
+        end
+
+        # Symbols in the same scope are differentiated
+        # only by the name
+        def_hash @name
+        def_equals @name
+
+        # String representation of the symbol is nothing
+        # but a name
+        def to_s
+            return @name
+        end
+    end
+
+    # Entry in the symbol table for pseudosymbols (the hints
+    # to the compiler, such as _unroll)
+    class PseudoSymbol < Symbol
+        def to_s
+            "~" + super.to_s
+        end
+    end
+
+    # Entry in the symbol table representing an instance
+    class StorageKey < Key
+
+        # Constructs the storage key - the combination
+        # of the storage and the index in the storage
+        # (for example using struct storage and the field index,
+        # we can refer to a specific field in the struct's instance)
+        #
+        # Params:
+        #     storage = storage instance
+        #     idx = index in the storage instance
+        def initialize(@storage : Storage, @idx : Int32)
+        end
+
+        # StorageKey's identity is a combination of the storage
+        # instance and the index
+        def_hash @storage, @idx
+        def_equals @storage, @idx
+    end
+end

--- a/src/frontend/symbol_table_value.cr
+++ b/src/frontend/symbol_table_value.cr
@@ -1,0 +1,14 @@
+module Isekai
+
+# Defines an entry in the symbol table. The symbol table
+# holds both types and expressions (under the different symbol name).
+abstract class SymbolTableValue
+    # Returns the size of the symbol. For the abstract entry,
+    # the size is negative. For the concrete types this would be
+    # number of bytes for the type.
+    def sizeof
+        return -1
+    end
+end
+
+end

--- a/src/frontend/types.cr
+++ b/src/frontend/types.cr
@@ -1,0 +1,149 @@
+require "./symbol_table_value.cr"
+
+module Isekai
+
+# A common ansector class for all types in the program.
+# We know four type classes: a void type - a result of
+# an expression with no value; integer/unsigned type;
+# an array type - the array containing fixed number of
+# elements of the same type; and a struct - the record
+# containing the fixed number of different types, accessible
+# by fields. The last type is a pointer type which is a type
+# that references another type.
+class Type < SymbolTableValue
+end
+
+# The void type - result of an expression that yields no value
+# (it only performs side effects).
+class Void < Type
+end
+
+# The signed integer type.
+class IntType < Type
+    # Returns the size of the type.
+    def sizeof
+        return 1
+    end
+end
+
+# The unsigned integer type.
+class UnsignedType < IntType
+    # Returns the size of the type.
+    def sizeof
+        return 1 
+    end
+end
+
+# Array type. Contains fixed number elements of a single type.
+class ArrayType < Type
+    # Constucts an array.
+    # Params:
+    #     type = type of the array's elements
+    #     size = number of the array's elements 
+    def initialize (@type : Type, @size : Int32)
+    end
+end
+
+# Struct field. A single field in a struct referencable
+# by its name.
+class StructField
+    # Constructs an struct field
+    # Params:
+    #     type = field type
+    #     label = struct field's label (also known as field name)
+    def initialize (@type : Type, @label : String)
+    end
+end
+
+# Struct type. A structured record consisted by the number
+# of StructFields.
+class StructType < Type
+    # Array of the struct fields' offsets in the memory.
+    # All fields in a structs are stored inside a contigous block
+    # of memory. Every field is stored at the offset that's a sum
+    # of all previous fields' size. This array has an element for
+    # every struct's field and it's representing the field's offset
+    # in memory.
+    @offsets : Array(Int32)
+
+    # Constructs a struct.
+    # Params:
+    #     label = name of the struct type
+    #     fields = array of struct fields.
+    def initialize (@label : String, @fields : Array(StructField))
+        # Reserve the memory for the offests. The last
+        # element of the offsets array is the offset of the end
+        # of the struct (the sum of all fields' types' sizes).
+        @offsets = [0] * (fields.size + 1)
+            
+        # Caclulate the offsets for every field.
+        # Offests(i+1) = Offsets(i) + Field(i).sizeof
+        (0..@offsets.size-2).each do |i|
+            @offsets[i+1] = @offsets[i] + @fields[i].@type.sizeof
+        end
+    end
+
+    # Returns the size of the structure.
+    def sizeof
+        # the size of the structure is the same as the last offset.
+        return @offsets[-1]
+    end
+
+    # Returns the offset of the particular field
+    # Params:
+    #     field_label = label of the field to lookup
+    # Returns:
+    #     the offset of the struct's field
+    def offsetof(field_label)
+        return @offsets[indexof(field_label)]
+    end
+
+    # Returns the value of the particular field
+    # Params:
+    #     field_label = label of the field to lookup
+    # Returns:
+    #     the value of the struct's field
+    def get_field(field_label)
+        return @fields[indexof(field_label)]
+    end
+
+    # Gets the index of the field in the value and offest's
+    # array.
+    #
+    # Params:
+    #     field_label = label of the field to lookup
+    # Returns:
+    #     the index of the struct's field determined by the label.
+    #
+    private def indexof (field_label)
+        result : StructField|Nil = nil
+        i = 0
+        index = 0
+
+        # Perform a linear search in the fields array
+        @fields.each do |field|
+            if field.@label == field_label
+                index = i 
+                result = field
+                break
+            end
+            i += 1
+        end
+        if result.is_a? Nil
+            raise "No such struct field"
+        end
+
+        return index
+    end
+end
+
+# Pointer type. References another (base) type.
+class PtrType < Type
+    # Constructs the pointer type.
+    #
+    # Params:
+    #     base_type = base type which this pointer references.
+    def initialize (@base_type : Type)
+    end
+end
+end


### PR DESCRIPTION
This adds the intermediate graph definition. The DFGExpr is the node
representing the expression, which can be constant, binary or unary
operation.

Blocked on #5 