### PR TITLE
Build docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-isekai: src/isekai.cr $(wildcard src/**/*.cr)
+isekai: src/isekai.cr $(wildcard src/**/*.cr) $(wildcard src/*.cr)
 	crystal build src/isekai.cr
 
 .PHONY: test
-test: $(wildcard src/**/*.cr) $(wildcard spec/*.cr)
+test: $(wildcard src/**/*.cr) $(wildcard src/*.cr) $(wildcard spec/*.cr)
 	crystal spec
+
+.PHONY: container_test
+container_test: $(wildcard src/**/*.cr) $(wildcard src/*.cr) $(wildcard spec/*.cr)
+	docker run -w $(PWD) -v $(PWD):$(PWD) isekai crystal spec
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -26,12 +26,33 @@ can be used.
 
 The project is written in Crystal language. Follow the [Official
 instructions](https://crystal-lang.org/docs/installation/) for instructions how
-to install Crystal lang. The only library dependency is `libclang` library. On
-Ubuntu it can be installed via `sudo apt install libclang1-6.0 clang-6.0`
+to install Crystal lang. 
 
-### Installing libclang on Debian 9
+Since the project depends on several libclang patches which are not
+yet merged in the libclang (https://www.mail-archive.com/cfe-commits@cs.uiuc.edu/msg95414.html,
+http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20140428/104048.html), the easiest
+is to use the provided pre-build binary and to build and run the software inside
+a container.
 
-To install libclang on Debian 9, the steps are:
+### Installing docker
 
-1. Add https://apt.llvm.org/'s repo as listed
-2. apt install clang-6.0-dev
+To install docker on Ubuntu, follow the [official instructions](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+
+### Building and running inside docker container
+
+To build a docker image with the `isekai` tag, enter `docker` directory and run `make image`.
+This will build `isekai` image which then you can use to spawn a container and mount
+the main directory:
+
+```
+docker run -w $PWD -v $PWD:$PWD -ti isekai /bin/bash
+```
+
+where you can run `make`, `make test` and run the built binaries.
+
+If you don't want to enter the interactive console, it's enough to
+run make within the container:
+
+```
+docker run -w $PWD -v $PWD:$PWD isekai make test
+```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ To build a docker image with the `isekai` tag, enter `docker` directory and run 
 This will build `isekai` image which then you can use to spawn a container and mount
 the main directory:
 
+#### Note
+
+You may need crystal lang dependencies before running this step:
+
+```
+shards update
+```
+
+
 ```
 docker run --rm -w $PWD -v $PWD:$PWD -ti isekai /bin/bash
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will build `isekai` image which then you can use to spawn a container and m
 the main directory:
 
 ```
-docker run -w $PWD -v $PWD:$PWD -ti isekai /bin/bash
+docker run --rm -w $PWD -v $PWD:$PWD -ti isekai /bin/bash
 ```
 
 where you can run `make`, `make test` and run the built binaries.
@@ -54,5 +54,5 @@ If you don't want to enter the interactive console, it's enough to
 run make within the container:
 
 ```
-docker run -w $PWD -v $PWD:$PWD isekai make test
+docker run --rm -w $PWD -v $PWD:$PWD isekai make test
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:bionic
+
+RUN apt update
+RUN apt install -y gnupg2 curl apt-transport-https
+RUN curl -sL "https://keybase.io/crystal/pgp_keys.asc" | apt-key add -
+RUN echo "deb https://dist.crystal-lang.org/apt crystal main" > /etc/apt/sources.list.d/crystal.list
+RUN curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" > /etc/apt/sources.list.d/llvm.list
+RUN apt-get update
+RUN apt install -y crystal libclang-7-dev clang-7
+COPY bin/libclang.so.gz /tmp/libclang.so.gz
+RUN gzip -d /tmp/libclang.so.gz
+RUN cp /tmp/libclang.so /usr/lib/x86_64-linux-gnu/libclang-7.so.1
+RUN cp /tmp/libclang.so /usr/lib/libclang.so.7

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,4 @@
+.PHONY: image
+
+image:
+	docker build . -t isekai


### PR DESCRIPTION
Since the project depends on several libclang patches which are not yet
merged in the libclang
(https://www.mail-archive.com/cfe-commits@cs.uiuc.edu/msg95414.html,
http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20140428/104048.html),
the easiest is to use the provided pre-build binary and to build and run
the software inside a container.

Unfortunatelly, there doesn't seem to be any workaround in using
upstream libraries at this point.